### PR TITLE
Fix: Use ${node_bin} for the node binary

### DIFF
--- a/LSP-yaml.sublime-settings
+++ b/LSP-yaml.sublime-settings
@@ -1,4 +1,5 @@
 {
+	"command": ["${node_bin}", "${server_path}", "--stdio"],
 	"languages": [
 		{
 			"languageId": "yaml",

--- a/plugin.py
+++ b/plugin.py
@@ -1,5 +1,5 @@
-import os
 from lsp_utils import NpmClientHandler
+import os
 
 
 def plugin_loaded():


### PR DESCRIPTION
With the latest version of lsp_utils a change was introduced [1] that allows using a locally
managed node runtime instead of the system one. For that to work, the "node" command
needs to use a variable.

[1] https://github.com/sublimelsp/lsp_utils/commit/403345a0c5c15e84802c712044c630a9fb236b9d