### PR TITLE
Handle `json-schema` URI schemes

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,5 +1,9 @@
+from LSP.plugin.core.typing import Callable
 from lsp_utils import NpmClientHandler
 import os
+import sublime
+import urllib.parse
+import urllib.request
 
 
 def plugin_loaded():
@@ -16,3 +20,24 @@ class LspYamlPlugin(NpmClientHandler):
     server_binary_path = os.path.join(
         server_directory, 'node_modules', 'yaml-language-server', 'bin', 'yaml-language-server'
     )
+
+    def on_open_uri_async(self, uri: str, callback: Callable[[str, str, str], None]) -> bool:
+        if not uri.startswith("json-schema:"):
+            return False
+
+        def run_blocking() -> None:
+            # TODO: Make async!
+            parsed = urllib.parse.urlparse(uri)
+            http_url = urllib.parse.unquote(parsed.fragment)
+            with urllib.request.urlopen(http_url) as f:
+                content = f.read().decode('utf-8')
+            content = content.replace("\r", "")
+            syntaxes = sublime.find_syntax_by_scope("source.json")
+            if not syntaxes:
+                path = "Packages/Plain Text/Plain Text.tmLanguage"
+            else:
+                path = syntaxes[0].path
+            callback(urllib.parse.urldefrag(uri).url, content, path)
+
+        sublime.set_timeout_async(run_blocking)
+        return True

--- a/plugin.py
+++ b/plugin.py
@@ -30,8 +30,7 @@ class LspYamlPlugin(NpmClientHandler):
             parsed = urllib.parse.urlparse(uri)
             http_url = urllib.parse.unquote(parsed.fragment)
             with urllib.request.urlopen(http_url) as f:
-                content = f.read().decode('utf-8')
-            content = content.replace("\r", "")
+                content = f.read().decode('utf-8').replace("\r", "")
             callback(urllib.parse.urldefrag(uri).url, content, "scope:source.json")
 
         sublime.set_timeout_async(run_blocking)

--- a/plugin.py
+++ b/plugin.py
@@ -32,12 +32,7 @@ class LspYamlPlugin(NpmClientHandler):
             with urllib.request.urlopen(http_url) as f:
                 content = f.read().decode('utf-8')
             content = content.replace("\r", "")
-            syntaxes = sublime.find_syntax_by_scope("source.json")
-            if not syntaxes:
-                path = "Packages/Plain Text/Plain Text.tmLanguage"
-            else:
-                path = syntaxes[0].path
-            callback(urllib.parse.urldefrag(uri).url, content, path)
+            callback(urllib.parse.urldefrag(uri).url, content, "scope:source.json")
 
         sublime.set_timeout_async(run_blocking)
         return True


### PR DESCRIPTION
This language server shows a Code Lens at the top of the file that you can
click on. It results in the client doing a workspace/executeCommand request.
When yaml-language-server receives that request, it in turn does a
window/showDocument request to the client. The URI of that window/showDocument
request has a `json-schema:` scheme. The fragment of that URI contains a HTTP
URL that you can use to fetch the JSON schema associated to the current YAML
file.

Depends on https://github.com/sublimelsp/LSP/pull/1747 as there was a bug in the window/showDocument request handler.