### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from LSP.plugin import ClientConfig
-from lsp_utils import NpmClientHandler
-from typing import final
-from typing_extensions import override
 import functools
 import os
-import sublime
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
+from typing import final
+
+import sublime
+from LSP.plugin import ClientConfig
+from lsp_utils import NpmClientHandler
+from typing_extensions import override
 
 
 def plugin_loaded() -> None:

--- a/plugin.py
+++ b/plugin.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import functools
-import os
-import urllib.parse
-import urllib.request
 from collections.abc import Callable
-from typing import final
-
-import sublime
 from LSP.plugin import ClientConfig
 from lsp_utils import NpmClientHandler
+from typing import final
 from typing_extensions import override
+import functools
+import os
+import sublime
+import urllib.parse
+import urllib.request
 
 
 def plugin_loaded() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,7 @@ ignore = ["E203"]
 "boot.py" = ["E402"]
 
 [tool.ruff.lint.isort]
-case-sensitive = false
-force-single-line = true
-from-first = true
-no-sections = true
+case-sensitive = true
+combine-as-imports = true
 order-by-type = false
 required-imports = ["from __future__ import annotations"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,8 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "F401"]
+select = ["E", "F", "W", "I", "UP"]
 ignore = ["E203"]
-preview = true
 
 [tool.ruff.lint.per-file-ignores]
 "boot.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,17 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP"]
+select = ["E", "F", "W", "I", "UP", "F401"]
 ignore = ["E203"]
+preview = true
 
 [tool.ruff.lint.per-file-ignores]
 "boot.py" = ["E402"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)